### PR TITLE
Unpin setuptools to allow building with latest version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ publish = [
 
 [build-system]
 requires = [
-    "setuptools~=67.6"
+    "setuptools>=67.6"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
I am updating setuptools used in [nixpkgs](https://github.com/NixOS/nixpkgs) to the latest version (currently 68.0.0) so would like to relax this constraint. I see that other dependencies are pinned to the minor version, and I would also be open to updating and doing that for setuptools, but I feel like this requires less work (no work unless a bug or change is actually discovered).